### PR TITLE
add MAT memory analyzer guide

### DIFF
--- a/content/blog/mat-memory-analyzer/index.md
+++ b/content/blog/mat-memory-analyzer/index.md
@@ -1,0 +1,685 @@
+---
+title: "Eclipse MAT 实战指南：用 Memory Analyzer 定位 Java 内存泄漏、OOM 与高内存占用"
+description: "从 Heap Dump 获取、Histogram、Dominator Tree、Path to GC Roots、OQL，到 Leak Suspects 与集合分析，系统掌握 Eclipse MAT 的 Java 内存问题定位方法。"
+summary: "一篇讲透 Eclipse MAT 的实战文章，覆盖 OOM、内存泄漏、高内存占用、集合浪费与 OQL 查询。"
+date: 2026-06-21T21:00:00+08:00
+lastmod: 2026-06-21T21:00:00+08:00
+draft: false
+weight: 50
+categories: ["Java", "JVM", "性能优化"]
+tags: ["MAT", "Eclipse MAT", "Memory Analyzer", "Java", "JVM", "OOM", "内存泄漏", "Heap Dump", "OQL"]
+contributors: ["l10178"]
+pinned: true
+homepage: false
+type: docs
+seo:
+  title: "Eclipse MAT 实战指南：定位 Java 内存泄漏、OOM 与高内存占用"
+  description: "系统讲解 Eclipse Memory Analyzer Tool 的核心概念与排障路径，帮助快速定位 Java Heap Dump 中的内存问题。"
+  canonical: ""
+  noindex: false
+---
+
+OOM、内存泄漏和“服务没挂但内存就是下不来”，几乎是每个 Java 团队迟早会遇到的问题。
+
+很多人第一次接触 Heap Dump 时，都会有同样的感觉：文件很大、对象很多、信息很杂，但不知道该从哪里下手。Eclipse MAT（Memory Analyzer Tool）之所以经典，不是因为它能把 Heap Dump 打开，而是因为它能把“谁占了内存、谁把对象留住了、哪些集合在浪费空间、哪一条引用链导致对象无法回收”这些关键问题变得可见。
+
+这篇文章会基于一篇早期内部整理材料，结合 **2026 年最新的官方资料与当前 MAT 能力**，重新整理成一套更完整的 Java 内存分析指南。重点不是罗列功能，而是建立一条稳定的分析路径：
+
+1. 先确认你拿到的是不是“有价值”的 Heap Dump。
+2. 再从 Top Consumers / Histogram 找到占用内存最多的对象。
+3. 用 Dominator Tree 和 Path to GC Roots 找到“为什么不能回收”。
+4. 最后用 OQL、集合分析和 Leak Suspects 把问题收敛成可落地的修复动作。
+
+如果你只想先拿走一个结论，可以记住下面这句话：
+
+> **MAT 最核心的价值不是“看对象”，而是“解释对象为什么还活着”。**
+
+## MAT 是什么，适合解决什么问题
+
+Eclipse MAT 是一个专门分析 **Java Heap Dump** 的工具。官方对它的定义很直接：它是一个快速、功能完整的 Java 堆分析器，擅长发现 **内存泄漏** 和 **高内存占用** 问题。
+
+结合官方文档和实际使用场景，MAT 最适合解决四类问题：
+
+- **Java OOM**：比如 `java.lang.OutOfMemoryError: Java heap space`
+- **堆内存持续上涨**：服务不一定崩，但 Full GC 后仍回不去
+- **内存浪费**：集合容量过大、重复字符串过多、零长度数组泛滥
+- **对象保活链不清楚**：明明业务逻辑已经结束，但对象还是被引用着
+
+它不适合直接解决所有“内存高”的问题。
+
+举个很现实的例子：
+
+- 如果问题在 **堆内**，MAT 往往非常有效。
+- 如果问题主要是 **堆外内存**、**DirectByteBuffer**、**JNI/native memory**、**glibc/jemalloc** 或 **容器 page cache**，MAT 只能帮你看到边界，不能独立给出全部答案。
+
+所以更准确地说：
+
+> **MAT 是 Java 堆问题的一线工具，而不是所有内存问题的万能钥匙。**
+
+## 先建立一个正确的心智模型
+
+在真正打开 MAT 之前，先把几个概念讲清楚。否则后面看到 Histogram、Retained Heap、GC Roots 时，很容易“每个词都认识，连起来不知道什么意思”。
+
+### 1. Heap Dump 是什么
+
+Heap Dump 是某一个时刻 **Java 对象图的快照**。它记录了 JVM 堆里当时还活着的对象、它们的字段值以及对象之间的引用关系，常见格式是 `.hprof`。
+
+它不是监控曲线，也不是持续采样，而是一张静态快照。你分析的是：
+
+- 某个时间点到底有哪些对象
+- 哪些对象占得多
+- 哪些对象互相引用
+- 哪些对象之所以还活着，是因为被谁一路引用着
+
+### 2. 什么叫内存泄漏
+
+在 Java 里，“内存泄漏”不是 C/C++ 意义上的“malloc 了但没人 free”。
+
+更准确的定义是：
+
+> **对象在业务上已经没用了，但在引用关系上仍然可达，GC 不能回收。**
+
+也就是说，问题的本质不是“对象大”，而是“对象不该活着却还活着”。
+
+### 3. GC Roots 是什么
+
+GC Roots 是 JVM 判定对象是否存活的起点。只要一个对象还能沿着引用链追溯到某个 GC Roots，它就会被认为是“还活着”。
+
+常见 GC Roots 包括：
+
+- 当前线程调用栈上的局部变量和方法参数
+- 正在运行的线程对象本身
+- 系统类加载器加载的类
+- JNI / Native 代码持有的活动对象
+- 静态字段引用的对象
+
+这也是为什么很多经典泄漏都和这些东西有关：
+
+- `static Map`
+- `ThreadLocal`
+- 长生命周期线程池
+- 缓存未清理
+- Listener / Callback 没注销
+- ClassLoader 没卸载
+
+### 4. 强引用、软引用、弱引用、虚引用
+
+很多 Java 面试会问这几个概念，但在 MAT 里，它们不是八股，而是非常实用的分析线索。
+
+- **强引用（Strong Reference）**：最普通的引用，只要强引用链还在，对象就不会被回收。
+- **软引用（SoftReference）**：更适合做内存敏感缓存，内存紧张时才会回收。
+- **弱引用（WeakReference）**：GC 一扫到就可能回收，典型场景是 `WeakHashMap`。
+- **虚引用（PhantomReference）**：本身拿不到对象，主要用于更精细的资源回收跟踪。
+
+在 MAT 里，这些引用类型非常重要，因为 **查“Path to GC Roots”时，通常会排除 soft / weak / phantom references**，避免你把“本来就可回收”的对象误判成泄漏。
+
+## MAT 里最重要的 6 个能力
+
+如果你是第一次真正使用 MAT，不需要一上来就把所有菜单点一遍。先抓住以下 6 个能力就足够应对大多数问题。
+
+### 1. Histogram
+
+Histogram 类似“按类聚合后的对象统计表”。你会看到：
+
+- 每个类有多少实例
+- Shallow Heap 大小
+- 该类对象集合大致占了多少内存
+
+它非常适合做第一轮扫描：
+
+- 哪些类实例数异常多
+- 哪些集合类占比很高
+- 是否有意料之外的大量 `String`、`byte[]`、`char[]`
+
+`byte[]`、`char[]` 排在前面很常见，不代表一定有问题。真正有价值的是：
+
+- **数量是否异常**
+- **是谁持有这些数组**
+- **这些数组是否属于某个业务对象、缓存或中间结果**
+
+### 2. Dominator Tree
+
+Dominator Tree 是 MAT 最强大的视图之一。
+
+它回答的问题不是“谁大”，而是：
+
+> **如果把某个对象去掉，连带能释放多少对象？**
+
+换句话说，Dominator Tree 更像“保活控制树”。
+
+如果从 GC Roots 到某个对象 Y 的所有路径都必须经过 X，那么就说 **X dominates Y**。
+
+这意味着：
+
+- X 是关键持有者
+- 只要 X 不释放，Y 就不可能释放
+- 找到 X，往往就找到了问题的真正根节点
+
+在实战里，Dominator Tree 特别适合做这两件事：
+
+- 找“谁把大对象簇握在手里”
+- 找“某个缓存、集合、类加载器到底拖住了多少对象”
+
+### 3. Path to GC Roots
+
+如果说 Dominator Tree 用来找“大方向”，那么 Path to GC Roots 就是查“犯罪链条”。
+
+你选中一个可疑对象后，可以查看它到 GC Roots 的最短路径。这个路径通常能明确告诉你：
+
+- 是哪个线程栈把它留住了
+- 是哪个静态字段引用了它
+- 是哪个 `ThreadLocalMap` 或缓存容器持有了它
+- 是哪个 ClassLoader 整体把一批对象拖住了
+
+这是排查 Java 泄漏最关键的一步。
+
+在实际操作里，**优先勾选排除 soft / weak / phantom references**，只看强引用链。否则路径会很杂，容易把真正的问题淹没掉。
+
+### 4. Retained Heap / Retained Set
+
+Shallow Heap 只看对象本身占用的空间。
+
+Retained Heap 看的是：
+
+> **如果当前对象被回收，连带可以释放掉多少内存。**
+
+这才更接近“这个对象真实值多少钱”。
+
+比如一个 `ArrayList` 本身可能只有几十个字节，但它下面挂了 10 万个对象。那么真正值得关注的是它的 **Retained Heap**，而不是自己的浅表大小。
+
+### 5. OQL（Object Query Language）
+
+OQL 是 MAT 里非常值得掌握的能力。它允许你像查数据库一样查 Heap Dump。
+
+它的基本语义很简单：
+
+- 类 = 表
+- 对象 = 行
+- 字段 = 列
+
+例如：
+
+```sql
+SELECT * FROM java.util.ArrayList WHERE size = 0
+```
+
+典型用途包括：
+
+- 找空集合
+- 找未使用过的集合
+- 找某个类的所有实例
+- 按条件筛选大对象
+- 验证某个怀疑是否成立
+
+MAT 的很多高级分析其实都可以用 OQL 来补刀。
+
+### 6. Leak Suspects Report
+
+官方明确提到，MAT 可以自动生成 **Leak Suspects Report**。这不是银弹，但非常适合作为“第一版机器意见”。
+
+它会尝试自动告诉你：
+
+- 哪些对象看起来像泄漏嫌疑人
+- 哪些引用链最可疑
+- 某些对象为什么占比很高
+
+我的建议是：
+
+- **先看报告，快速建立直觉**
+- **不要直接相信报告结论**
+- **一定回到 Histogram / Dominator Tree / GC Roots 自己验证**
+
+因为 Leak Suspects 很擅长给你方向，但不一定能给你最终真相。
+
+## 如何获取高质量 Heap Dump
+
+分析结果的上限，通常由 Heap Dump 质量决定。
+
+如果 Dump 抓得不对，后面 MAT 再强也白搭。
+
+### OOM 时自动生成 Heap Dump
+
+这是生产环境里最推荐的基础配置：
+
+```bash
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:HeapDumpPath=/path/to/dumps/
+```
+
+这样 JVM 发生 OOM 时会自动把 Heap Dump 写出来。
+
+这类 Dump 的优点很明显：
+
+- 时机准确
+- 最接近故障现场
+- 适合排查真正导致崩溃的问题
+
+### 在线手工导出 Heap Dump
+
+常见方法包括：
+
+```bash
+jcmd <pid> GC.heap_dump /path/to/dump.hprof
+jmap -dump:format=b,file=/path/to/dump.hprof <pid>
+```
+
+如果你已经确定是线上异常内存增长，但还没 OOM，这类方法非常适合做主动排查。
+
+### 导出前尽量先做一次 GC
+
+如果你的目标是找“泄漏对象”，而不是单纯想看“当前所有业务对象”，那么导出前先触发一次 GC 往往更有价值。
+
+原因很简单：
+
+- 能减少本来就可回收的垃圾对象干扰
+- 能让引用链更干净
+- 更容易锁定“GC 后仍然活着”的问题对象
+
+当然，这条建议不是绝对的。
+
+如果你要排查的是：
+
+- 某次请求期间对象暴涨
+- 某个批处理过程中内存尖峰
+- 某类对象短期大量堆积
+
+那么“触发 GC 后再导出”可能会把现场抹掉。这时更重要的是 **抓对时机**。
+
+## 一条真正可落地的 MAT 排障路径
+
+很多文章把 MAT 功能一项项讲完，但读者真正到线上排障时，还是会卡住：先点哪里？看到什么算异常？下一步该去哪？
+
+下面给你一条我更推荐的路径。
+
+### 第一步：先判断是“谁大”，还是“谁留住了谁”
+
+打开 Heap Dump 后，先看：
+
+- Overview
+- Top Consumers
+- Histogram
+
+你此时的目标不是得出结论，而是做分类：
+
+#### 情况 A：明显是某类对象数量异常多
+
+例如：
+
+- 大量 `byte[]`
+- 大量 `String`
+- 大量某业务 DTO
+- 大量 `HashMap$Node`
+- 大量缓存对象
+
+这种情况优先走：
+
+> Histogram → Drill Down → Dominator Tree → Path to GC Roots
+
+#### 情况 B：单个对象本身不大，但 Retained Heap 异常高
+
+例如一个 `ArrayList`、`ConcurrentHashMap`、`ClassLoader`、`Thread` 本身没多大，但下面挂了一大片对象。
+
+这种情况优先走：
+
+> Dominator Tree → Immediate Dominator → Path to GC Roots
+
+### 第二步：在 Dominator Tree 里找真正的“保活控制点”
+
+你经常会看到一个很有迷惑性的场景：
+
+- 最大的是 `byte[]`
+- 第二大的是 `char[]`
+- 然后你开始怀疑是不是字符串太多
+
+但真正的问题可能根本不是字符串，而是：
+
+- 某个缓存容器一次性存了很多数据
+- 某个线程上下文没清理
+- 某个类加载器没有卸载
+- 某个监听器链条一直把对象挂着
+
+所以，**不要只盯着叶子对象，要盯着谁在上游支配它们。**
+
+### 第三步：用 Path to GC Roots 证明“为什么还活着”
+
+这一步是把怀疑变成证据。
+
+常见几种结果：
+
+#### 1. `ThreadLocalMap` 链条
+
+这是最经典的 Java 泄漏之一。
+
+典型现象：
+
+- 在线程池线程里放了 `ThreadLocal`
+- 用完没 `remove()`
+- 线程池线程不退出
+- 值对象一直被间接引用
+
+你在 GC Roots 里往往会看到：
+
+- `Thread`
+- `threadLocals`
+- `ThreadLocalMap`
+- 你的 value 对象
+
+这类问题修复通常非常直接：
+
+- `try/finally` 中 `remove()`
+- 避免把大对象、流对象、请求上下文塞进 `ThreadLocal`
+- 能不用就不用
+
+#### 2. `static` 字段或单例缓存
+
+你会看到：
+
+- 某个类的静态字段
+- 指向一个 `Map` / `List` / 缓存对象
+- 再一路挂着大量业务对象
+
+这类问题要问的不是“为什么它活着”，而是：
+
+- 这个缓存是否有上限？
+- 是否有淘汰策略？
+- 是否应该按请求、租户、时间窗口分片？
+- 是否有生命周期结束后的清理逻辑？
+
+#### 3. ClassLoader 泄漏
+
+这类问题在插件化、脚本执行、动态编译、热部署框架中很常见。
+
+常见原因：
+
+- 类加载器加载的类里有静态对象
+- 线程上下文 ClassLoader 没切回来
+- 某些全局注册表持有旧 ClassLoader 的类实例
+- 定时任务、线程池、JDBC 驱动、日志框架没解绑
+
+如果你在 MAT 里发现某个 ClassLoader Retained Heap 非常大，那就要警惕了。
+
+#### 4. 集合型容器无限增长
+
+最常见，也最容易被忽略。
+
+比如：
+
+- 未设上限的 `Map`
+- 请求结果一直 append 的 `List`
+- 失败重试队列没人消费
+- 本地缓存 key 设计失控
+
+修复动作一般包括：
+
+- 加 TTL / LRU / size limit
+- 只存必要字段
+- 分批处理，及时清空中间态
+- 不要把“结果全集”长期堆在内存里
+
+## MAT 里几个特别实用的分析专题
+
+### 1. 空集合与低填充率集合
+
+这类问题通常不会单独把服务打挂，但它们会在大型系统里持续吞噬内存。
+
+例如：
+
+- 每个节点都 eager 初始化一个 `ArrayList`
+- 大量集合始终为空
+- 预分配容量很大，但实际只放一两个元素
+
+MAT 官方文档对这类问题支持很好，尤其是：
+
+- Empty Collections
+- Collection Fill Ratio
+- Array Fill Ratio
+
+你可以很快看出：
+
+- 哪些集合为空却还持有 backing array
+- 哪些集合 fill ratio 极低
+- 谁是这些集合的 dominator
+
+这类问题常见修复方式：
+
+- 延迟初始化（lazy init）
+- 改默认容量
+- 用共享空集合 / 空数组
+- 改成按需创建
+
+### 2. 重复字符串
+
+重复字符串也是特别常见的隐性浪费。
+
+例如：
+
+- 相同的配置 key 被反复创建
+- XML / JSON 解析后重复的字段名与值
+- 大量状态码、类型码、租户名、标签名
+
+MAT 的 Component Report 会专门分析 Duplicate Strings，这非常适合排查“内存没泄漏，但就是浪费得厉害”的系统。
+
+常见优化手段：
+
+- 用枚举或整数代替高重复短字符串
+- 对热点字符串做适度 `intern()`
+- 避免重复拷贝与重复 decode
+
+注意这里的关键词是 **适度**。
+
+`String.intern()` 不是一键省内存按钮，滥用也会带来额外维护成本和潜在副作用。
+
+### 3. Hash 冲突导致的性能问题
+
+这不是标准的“内存泄漏”，但 MAT 也能查。
+
+如果某些 `HashMap` / `Hashtable` 的 key 大量落到同一个 bucket，可能导致：
+
+- 查询效率下降
+- CPU 上升
+- 某些热点对象访问异常慢
+
+MAT 的 **Map Collision Ratio** 对这类问题很有帮助。
+
+当你看到：
+
+- 某个 Map 内存不一定特别大
+- 但冲突率很高
+
+就应该检查：
+
+- key 的 `hashCode()` 是否设计合理
+- key 是否字段过少、常量化严重
+- 是否把不适合作为 key 的对象直接拿来用了
+
+## OQL：几个真正常用的查询思路
+
+OQL 很强，但没必要背语法大全。真正常用的是这几类思路。
+
+### 查某个类的所有实例
+
+```sql
+SELECT * FROM com.example.MyCacheEntry
+```
+
+### 查某个类及其子类
+
+```sql
+SELECT * FROM INSTANCEOF java.util.AbstractMap
+```
+
+### 查空集合
+
+```sql
+SELECT * FROM java.util.ArrayList WHERE size = 0 AND modCount = 0
+```
+
+### 查空 Map
+
+```sql
+SELECT * FROM java.util.HashMap WHERE size = 0
+```
+
+### 查可疑的大集合
+
+```sql
+SELECT * FROM java.util.ArrayList WHERE size > 10000
+```
+
+### 查某个字段满足条件的对象
+
+比如你怀疑缓存条目里某个状态字段异常：
+
+```sql
+SELECT * FROM com.example.CacheEntry e WHERE e.status.toString() = "EXPIRED"
+```
+
+OQL 最适合的不是“替代所有图形分析”，而是：
+
+> **当你已经有怀疑时，用它快速验证。**
+
+## 一套实战排查案例模板
+
+如果你要带团队做分享，或者自己以后要复盘，这里我建议直接套用下面这个模板。
+
+### 场景：服务堆内存持续上涨，Full GC 后仍然居高不下
+
+#### 第 1 步：获取 Dump
+
+- 优先拿 OOM 时自动导出的 Dump
+- 如果没有，在线上稳定复现场景下用 `jcmd` 导出
+- 记录当时的监控与时间点
+
+#### 第 2 步：看 Top Consumers / Histogram
+
+- 找占比最高的类
+- 看是否出现异常多的 `String`、`byte[]`、业务对象、集合节点
+
+#### 第 3 步：切到 Dominator Tree
+
+- 找 retained heap 特别高的对象
+- 确认是哪个容器或哪条链路真正把对象留住
+
+#### 第 4 步：看 Path to GC Roots
+
+- 排除 soft / weak / phantom references
+- 看是否经过 `ThreadLocal`、`static`、ClassLoader、线程栈等
+
+#### 第 5 步：用 OQL / 集合分析补充验证
+
+- 是否有海量空集合
+- 是否是低填充率集合
+- 是否存在大量重复字符串
+- 是否某个缓存集合容量严重失控
+
+#### 第 6 步：回到代码确认修复点
+
+不要在 MAT 里停住。最后一定要落回代码：
+
+- 清理 `ThreadLocal`
+- 给缓存加边界
+- 调整生命周期管理
+- 限制中间结果大小
+- 关闭流、释放资源
+- 修复不合理的数据结构设计
+
+## MAT 不是万能的：什么时候要换工具
+
+这一点非常重要。
+
+如果你在 MAT 里怎么看都看不出问题，但内存还是高，通常说明问题可能不在“普通 Java 堆对象”上。
+
+这时要考虑转向：
+
+- **JFR / Java Flight Recorder**：看分配热点、线程阻塞、异常 GC 行为
+- **NMT（Native Memory Tracking）**：看堆外内存、线程栈、Code Cache、Metaspace
+- **async-profiler**：看 native alloc / CPU / lock
+- **Arthas**：现场看对象、线程、火焰图与 classloader
+- **系统层工具**：`pmap`、`smaps`、`cgroup` 指标、jemalloc / glibc 分析
+
+你可以把它们理解成一个分工：
+
+- MAT：解释 **堆对象为什么活着**
+- JFR：解释 **程序在运行时发生了什么**
+- NMT / native profiler：解释 **堆外内存去哪了**
+
+## 一个更适合团队落地的 MAT 使用建议
+
+如果你想把 MAT 真正带进团队，而不是“只有一两个人会用”，我建议这样推进。
+
+### 1. 固定一套排查顺序
+
+让大家先形成统一路径：
+
+- Dump 获取
+- Histogram
+- Dominator Tree
+- GC Roots
+- OQL 补充
+- 回到代码
+
+这样每次复盘都能共用语言。
+
+### 2. 把典型泄漏做成内部样例库
+
+非常值得沉淀的场景包括：
+
+- `ThreadLocal` 未清理
+- 本地缓存无限增长
+- 监听器未注销
+- ClassLoader 泄漏
+- 空集合浪费
+- 重复字符串泛滥
+- 错误的 Map key 设计导致碰撞和保活异常
+
+### 3. 区分“泄漏”和“浪费”
+
+这两个问题在优化优先级上不一样：
+
+- **泄漏**：对象不该活着却一直活着，通常优先级更高
+- **浪费**：对象活着是合理的，但空间使用方式不划算
+
+MAT 非常适合把这两者分清楚。
+
+## 2026 年还值得用 MAT 吗？
+
+答案是：**非常值得。**
+
+而且从官方最新发布来看，MAT 还在持续维护。2026 年 6 月发布的 **MAT 1.17.0** 已经更新到新的 Eclipse 平台，独立版运行最低要求也提升到了 **Java 21**。
+
+这背后其实说明了两件事：
+
+- MAT 不是“老工具遗产”，而是仍在演进
+- Java 生态对 Heap Dump 分析这件事，依然高度依赖它
+
+今天你当然可以用很多更现代的工具做在线分析、自动报告甚至 Web 化分析，但只要你真的需要手工啃一次 Heap Dump，MAT 依然是最值得掌握的基础能力之一。
+
+## 结语
+
+真正把 MAT 用好以后，你会发现它带来的最大变化不是“能看懂 hprof 文件”，而是你开始用一种更结构化的方式看待内存问题：
+
+- 大对象不一定是问题根因
+- 小对象也可能通过引用链拖住大块内存
+- OOM 不一定是“堆不够”，也可能是数据结构设计不当
+- 很多所谓“偶发问题”，其实都能在引用关系上找到证据
+
+最后送你一句非常实用的经验：
+
+> **排查 Java 内存问题时，先问“谁占了内存”，再问“谁让它活着”，最后问“它为什么本不该活着”。**
+
+把这三个问题搞清楚，MAT 的价值就真正发挥出来了。
+
+## 参考资料
+
+- Eclipse MAT 官方站点：<https://eclipse.dev/mat/>
+- Eclipse MAT 下载页：<https://eclipse.dev/mat/download/>
+- Eclipse MAT 官方文档首页：<https://help.eclipse.org/latest/topic/org.eclipse.mat.ui.help/welcome.html>
+- Eclipse MAT 基础教程：<https://help.eclipse.org/latest/topic/org.eclipse.mat.ui.help/gettingstarted/basictutorial.html>
+- Eclipse MAT 获取 Heap Dump：<https://help.eclipse.org/latest/topic/org.eclipse.mat.ui.help/tasks/acquiringheapdump.html>
+- Eclipse MAT OQL 查询：<https://help.eclipse.org/latest/topic/org.eclipse.mat.ui.help/tasks/queryingheapobjects.html>
+- Eclipse MAT Component Report：<https://help.eclipse.org/latest/topic/org.eclipse.mat.ui.help/reference/inspections/component_report.html>
+- Eclipse MAT Top Consumers：<https://help.eclipse.org/latest/topic/org.eclipse.mat.ui.help/reference/inspections/top_consumers.html>
+- Eclipse MAT Wiki：<https://wiki.eclipse.org/MemoryAnalyzer>
+- Eclipse MAT GitHub：<https://github.com/eclipse-mat/mat>
+- Lars Vogel：Eclipse Memory Analyzer 教程：<https://www.vogella.com/tutorials/EclipseMemoryAnalyzer/article.html>
+- 原始材料来源（转载页）：<http://www.lightskystreet.com/2015/09/01/mat_usage/>


### PR DESCRIPTION
## Summary
- add a new long-form blog post on Eclipse MAT for Java memory leak, OOM, and heap dump analysis
- restructure the original MAT notes into a polished article aligned with the current Hugo blog format
- supplement the article with up-to-date official MAT references and practical troubleshooting guidance

## Test plan
- [x] Run `hugo --quiet`
- [x] Review generated blog content in `content/blog/mat-memory-analyzer/index.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)